### PR TITLE
feat(AdminPedidoMedicamento1Controller): No procesar Farmapos + Diabetes

### DIFF
--- a/app/Http/Controllers/AdminPedidoMedicamento1Controller.php
+++ b/app/Http/Controllers/AdminPedidoMedicamento1Controller.php
@@ -663,7 +663,12 @@
 				'CAMPANA (Zona D)',
 			];
 
-			if (in_array($pedido->zona_residencia, $zonasProcesadas)) {
+			if (
+				in_array($pedido->zona_residencia, $zonasProcesadas)
+				&& !(
+					$pedido->zona_residencia == 'FARMAPOS' && $pedido->patologia == 2 // Excluir diabetes de FARMAPOS
+				)
+			) {
 				DB::select('CALL pedido_medicamento_to_processed(?, ?)', [$id, $pedido->nrosolicitud]);
 			}
 		}


### PR DESCRIPTION
Edité el condicional que procesa automáticamente los pedidos de Farmapos y Zonas A,B,C y D con el store procedure para que los pedidos que son de FARMAPOS y patología diabetes (2) no se procesen automáticamente